### PR TITLE
Insertion of poll instructions, continued

### DIFF
--- a/.depend
+++ b/.depend
@@ -2518,6 +2518,16 @@ asmcomp/comballoc.cmx : \
     asmcomp/comballoc.cmi
 asmcomp/comballoc.cmi : \
     asmcomp/mach.cmi
+asmcomp/dataflow.cmo : \
+    asmcomp/mach.cmi \
+    asmcomp/cmm.cmi \
+    asmcomp/dataflow.cmi
+asmcomp/dataflow.cmx : \
+    asmcomp/mach.cmx \
+    asmcomp/cmm.cmx \
+    asmcomp/dataflow.cmi
+asmcomp/dataflow.cmi : \
+    asmcomp/mach.cmi
 asmcomp/deadcode.cmo : \
     asmcomp/reg.cmi \
     asmcomp/proc.cmi \
@@ -2690,7 +2700,7 @@ asmcomp/liveness.cmo : \
     asmcomp/printmach.cmi \
     utils/misc.cmi \
     asmcomp/mach.cmi \
-    asmcomp/cmm.cmi \
+    asmcomp/dataflow.cmi \
     asmcomp/liveness.cmi
 asmcomp/liveness.cmx : \
     asmcomp/reg.cmx \
@@ -2698,7 +2708,7 @@ asmcomp/liveness.cmx : \
     asmcomp/printmach.cmx \
     utils/misc.cmx \
     asmcomp/mach.cmx \
-    asmcomp/cmm.cmx \
+    asmcomp/dataflow.cmx \
     asmcomp/liveness.cmi
 asmcomp/liveness.cmi : \
     asmcomp/mach.cmi

--- a/.depend
+++ b/.depend
@@ -2735,10 +2735,14 @@ asmcomp/mach.cmi : \
 asmcomp/polling.cmo : \
     utils/misc.cmi \
     asmcomp/mach.cmi \
+    asmcomp/dataflow.cmi \
+    asmcomp/cmm.cmi \
     asmcomp/polling.cmi
 asmcomp/polling.cmx : \
     utils/misc.cmx \
     asmcomp/mach.cmx \
+    asmcomp/dataflow.cmx \
+    asmcomp/cmm.cmx \
     asmcomp/polling.cmi
 asmcomp/polling.cmi : \
     utils/misc.cmi \

--- a/Changes
+++ b/Changes
@@ -97,6 +97,11 @@ Working version
 
 ### Code generation and optimizations:
 
+- #1400: Add an optional invariants check on Cmm, which can be activated
+  with the -dcmm-invariants flag
+  (Vincent Laviron, with help from Sebastien Hinderer, review by Stephen Dolan
+   and David Allsopp)
+
 - #9876: do not cache the young_limit GC variable in a processor register.
   This affects the ARM64, PowerPC and RISC-V ports, making signal handling
   and minor GC triggers more reliable, at the cost of a small slowdown.
@@ -118,10 +123,9 @@ Working version
 - #10349: Fix destroyed_at_c_call on RISC-V
   (Mark Shinwell, review by Nicolás Ojeda Bär)
 
-- #1400: Add an optional invariants check on Cmm, which can be activated
-  with the -dcmm-invariants flag
-  (Vincent Laviron, with help from Sebastien Hinderer, review by Stephen Dolan
-   and David Allsopp)
+- #10404: Add a generic backward dataflow analyzer and use it to speed up
+  liveness analysis
+  (Xavier Leroy, review by Gabriel Scherer, Greta Yorsh, Mark Shinwell)
 
 ### Type system:
 

--- a/asmcomp/dataflow.ml
+++ b/asmcomp/dataflow.ml
@@ -24,7 +24,7 @@ end
 
 module Backward(D: DOMAIN) = struct
 
-let analyze ?(exnhandler = fun x -> x) ~transfer instr =
+let analyze ?(exnhandler = fun x -> x) ?(exnescape = D.bot) ~transfer instr =
 
   let lbls =
     (Hashtbl.create 20 : (int, D.t) Hashtbl.t) in
@@ -80,7 +80,7 @@ let analyze ?(exnhandler = fun x -> x) ~transfer instr =
     | Iraise _ ->
         transfer i ~next:D.bot ~exn
   in
-    let b = before D.bot D.bot instr in
+    let b = before D.bot exnescape instr in
     (b, get_lbl)
 
 end

--- a/asmcomp/dataflow.ml
+++ b/asmcomp/dataflow.ml
@@ -1,0 +1,86 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*             Xavier Leroy, projet Cambium, INRIA Paris                  *)
+(*                                                                        *)
+(*   Copyright 2021 Institut National de Recherche en Informatique et     *)
+(*     en Automatique.                                                    *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+open Mach
+
+module type DOMAIN = sig
+  type t
+  val bot: t
+  val join: t -> t -> t
+  val lessequal: t -> t -> bool
+end
+
+module Backward(D: DOMAIN) = struct
+
+let analyze ?(exnhandler = fun x -> x) ~transfer instr =
+
+  let lbls =
+    (Hashtbl.create 20 : (int, D.t) Hashtbl.t) in
+  let get_lbl n =
+    match Hashtbl.find_opt lbls n with None -> D.bot | Some b -> b
+  and set_lbl n x =
+    Hashtbl.replace lbls n x in
+
+  let rec before end_ exn i =
+    match i.desc with
+    | Iend ->
+        transfer i ~next:end_ ~exn
+    | Ireturn | Iop (Itailcall_ind | Itailcall_imm _) ->
+        transfer i ~next:D.bot ~exn:D.bot
+    | Iop _ ->
+        let bx = before end_ exn i.next in
+        transfer i ~next:bx ~exn
+    | Iifthenelse(_, ifso, ifnot) ->
+        let bx = before end_ exn i.next in
+        let b1 = before bx exn ifso
+        and b0 = before bx exn ifnot in
+        transfer i ~next:(D.join b1 b0) ~exn
+    | Iswitch(_, cases) ->
+        let bx = before end_ exn i.next in
+        let b1 =
+          Array.fold_left
+            (fun accu case -> D.join accu (before bx exn case))
+            D.bot cases in
+        transfer i ~next:b1 ~exn
+    | Icatch(rc, handlers, body) ->
+        let bx = before end_ exn i.next in
+        begin match rc with
+        | Cmm.Nonrecursive ->
+            List.iter
+              (fun (n, h) -> set_lbl n (before bx exn h))
+            handlers
+        | Cmm.Recursive ->
+            let update changed (n, h) =
+              let b0 = get_lbl n in
+              let b1 = before bx exn h in
+              if D.lessequal b1 b0 then changed else (set_lbl n b1; true) in
+            while List.fold_left update false handlers do () done
+        end;
+        let b = before bx exn body in
+        transfer i ~next:b ~exn
+    | Iexit n ->
+        transfer i ~next:(get_lbl n) ~exn
+    | Itrywith(body, handler) ->
+        let bx = before end_ exn i.next in
+        let bh = exnhandler (before bx exn handler) in
+        let bb = before bx bh body in
+        transfer i ~next:bb ~exn
+    | Iraise _ ->
+        transfer i ~next:D.bot ~exn
+  in
+    let b = before D.bot D.bot instr in
+    (b, get_lbl)
+
+end

--- a/asmcomp/dataflow.mli
+++ b/asmcomp/dataflow.mli
@@ -28,6 +28,7 @@ end
 module Backward(D: DOMAIN) : sig
 
   val analyze: ?exnhandler: (D.t -> D.t) ->
+               ?exnescape: D.t ->
                transfer: (Mach.instruction -> next: D.t -> exn: D.t -> D.t) ->
                Mach.instruction ->
                D.t * (int -> D.t)
@@ -80,6 +81,10 @@ module Backward(D: DOMAIN) : sig
      the beginning of the handler and removes the register
      [Proc.loc_exn_bucket] that carries the exception value.  If not
      specified, [exnhandler] defaults to the identity function.
+
+     The optional [exnescape] argument deals with unhandled exceptions.
+     It is the abstract state corresponding to exiting the function on an
+     unhandled exception.  It defaults to [D.bot].
   *)
 
 end

--- a/asmcomp/dataflow.mli
+++ b/asmcomp/dataflow.mli
@@ -1,0 +1,85 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*             Xavier Leroy, projet Cambium, INRIA Paris                  *)
+(*                                                                        *)
+(*   Copyright 2021 Institut National de Recherche en Informatique et     *)
+(*     en Automatique.                                                    *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(* An abstract domain for dataflow analysis.  Defines a type [t]
+   of abstractions, with lattice operations. *)
+
+module type DOMAIN = sig
+  type t
+  val bot: t
+  val join: t -> t -> t
+  val lessequal: t -> t -> bool
+end
+
+(* Build a backward dataflow analysis engine for the given domain. *)
+
+module Backward(D: DOMAIN) : sig
+
+  val analyze: ?exnhandler: (D.t -> D.t) ->
+               transfer: (Mach.instruction -> next: D.t -> exn: D.t -> D.t) ->
+               Mach.instruction ->
+               D.t * (int -> D.t)
+
+  (* [analyze ~exnhandler ~transfer instr] performs a backward dataflow
+     analysis on the Mach instruction [instr], typically a function body.
+
+     It returns a pair of
+     - the abstract state at the function entry point;
+     - a mapping from catch handler label to the abstract state at the
+       beginning of the handler with this label.
+
+     The [transfer] function is called as [transfer i ~next ~exn].
+     - [i] is a sub-instruction of [instr].
+     - [next] is the abstract state "after" the instruction for
+       normal control flow, falling through the successor(s) of [i].
+     - [exn] is the abstract state "after" the instruction for
+       exceptional control flow, branching to the nearest exception handler
+       or exiting the function with an unhandled exception.
+
+     The [transfer] function, then, returns the abstract state "before"
+     the instruction.  The dataflow analysis will, then, propagate this
+     state "before" as the state "after" the predecessor instructions.
+
+     For compound instructions like [Iifthenelse], the [next] abstract
+     value that is passed to [transfer] is not the abstract state at
+     the end of the compound instruction (e.g. after the "then" and "else"
+     branches have joined), but the join of the abstract states at
+     the beginning of the sub-instructions.  More precisely:
+     - for [Iifthenelse(tst, ifso, ifnot)], it's the join of the
+       abstract states at the beginning of the [ifso] and [ifnot]
+       branches;
+     - for [Iswitch(tbl, cases)], it's the join of the abstract states
+       at the beginning of the [cases] branches;
+     - for [Icatch(recflag, body, handlers)] and [Itrywith(body, handler)],
+       it's the abstract state at the beginning of [body].
+
+     The [transfer] function is called for every sub-instruction of [instr],
+     as many times as needed to reach a fixpoint.  Hence, it can record
+     the results of the analysis at each sub-instruction in a mutable
+     data structure.  For instance, the transfer function for liveness
+     analysis updates the [live] fields of instructions as a side
+     effect.
+
+     The optional [exnhandler] argument deals with exception handlers.
+     This is a function that transforms the abstract state at the
+     beginning of an exception handler into the exceptional abstract
+     state for the instructions within the body of the handler.
+     Typically, for liveness analysis, it takes the registers live at
+     the beginning of the handler and removes the register
+     [Proc.loc_exn_bucket] that carries the exception value.  If not
+     specified, [exnhandler] defaults to the identity function.
+  *)
+
+end

--- a/asmcomp/liveness.ml
+++ b/asmcomp/liveness.ml
@@ -18,42 +18,31 @@
 
 open Mach
 
-let live_at_exit = ref []
+module Domain = struct
+  type t = Reg.Set.t
+  let bot = Reg.Set.empty
+  let join = Reg.Set.union
+  let lessequal = Reg.Set.subset
+end
 
-let find_live_at_exit k =
-  try
-    List.assoc k !live_at_exit
-  with
-  | Not_found -> Misc.fatal_error "Liveness.find_live_at_exit"
+module Analyzer = Dataflow.Backward(Domain)
 
-let live_at_raise = ref Reg.Set.empty
-
-let rec live i finally =
-  (* finally is the set of registers live after execution of the
-     instruction sequence.
-     The result of the function is the set of registers live just
-     before the instruction sequence.
-     The instruction i is annotated by the set of registers live across
-     the instruction. *)
+let transfer i ~next ~exn =
   match i.desc with
-    Iend ->
-      i.live <- finally;
-      finally
   | Ireturn | Iop(Itailcall_ind) | Iop(Itailcall_imm _) ->
       i.live <- Reg.Set.empty; (* no regs are live across *)
       Reg.set_of_array i.arg
   | Iop op ->
-      let after = live i.next finally in
-      if operation_is_pure op                  (* no side effects *)
-      && Reg.disjoint_set_array after i.res    (* results are not used after *)
-      && not (Proc.regs_are_volatile i.arg)    (* no stack-like hard reg *)
-      && not (Proc.regs_are_volatile i.res)    (*            is involved *)
+      if operation_is_pure op                 (* no side effects *)
+      && Reg.disjoint_set_array next i.res    (* results are not used after *)
+      && not (Proc.regs_are_volatile i.arg)   (* no stack-like hard reg *)
+      && not (Proc.regs_are_volatile i.res)   (*            is involved *)
       then begin
         (* This operation is dead code.  Ignore its arguments. *)
-        i.live <- after;
-        after
+        i.live <- next;
+        next
       end else begin
-        let across_after = Reg.diff_set_array after i.res in
+        let across1 = Reg.diff_set_array next i.res in
         let across =
           (* Operations that can raise an exception (function calls,
              bounds checks, allocations) can branch to the
@@ -61,83 +50,28 @@ let rec live i finally =
              Hence, everything that must be live at the beginning of
              the exception handler must also be live across this instr. *)
           if operation_can_raise op
-          then Reg.Set.union across_after !live_at_raise
-          else across_after in
+          then Reg.Set.union across1 exn
+          else across1 in
         i.live <- across;
         Reg.add_set_array across i.arg
       end
-  | Iifthenelse(_test, ifso, ifnot) ->
-      let at_join = live i.next finally in
-      let at_fork = Reg.Set.union (live ifso at_join) (live ifnot at_join) in
-      i.live <- at_fork;
-      Reg.add_set_array at_fork i.arg
-  | Iswitch(_index, cases) ->
-      let at_join = live i.next finally in
-      let at_fork = ref Reg.Set.empty in
-      for i = 0 to Array.length cases - 1 do
-        at_fork := Reg.Set.union !at_fork (live cases.(i) at_join)
-      done;
-      i.live <- !at_fork;
-      Reg.add_set_array !at_fork i.arg
-  | Icatch(rec_flag, handlers, body) ->
-      let at_join = live i.next finally in
-      let aux (nfail,handler) (nfail', before_handler) =
-        assert(nfail = nfail');
-        let before_handler' = live handler at_join in
-        nfail, Reg.Set.union before_handler before_handler'
-      in
-      let aux_equal (nfail, before_handler) (nfail', before_handler') =
-        assert(nfail = nfail');
-        Reg.Set.equal before_handler before_handler'
-      in
-      let live_at_exit_before = !live_at_exit in
-      let rec fixpoint before_handlers =
-        live_at_exit := before_handlers @ !live_at_exit;
-        let before_handlers' = List.map2 aux handlers before_handlers in
-        live_at_exit := live_at_exit_before;
-        match rec_flag with
-        | Cmm.Nonrecursive ->
-            before_handlers'
-        | Cmm.Recursive ->
-            if List.for_all2 aux_equal before_handlers before_handlers'
-            then before_handlers'
-            else fixpoint before_handlers'
-      in
-      let init_state =
-        List.map (fun (nfail, _handler) -> nfail, Reg.Set.empty) handlers
-      in
-      let before_handler = fixpoint init_state in
-      (* We could use handler.live instead of Reg.Set.empty as the initial
-         value but we would need to clean the live field before doing the
-         analysis (to remove remnants of previous passes). *)
-      live_at_exit := before_handler @ !live_at_exit;
-      let before_body = live body at_join in
-      live_at_exit := live_at_exit_before;
-      i.live <- before_body;
-      before_body
-  | Iexit nfail ->
-      let this_live = find_live_at_exit nfail in
-      i.live <- this_live ;
-      this_live
-  | Itrywith(body, handler) ->
-      let at_join = live i.next finally in
-      let before_handler = live handler at_join in
-      let saved_live_at_raise = !live_at_raise in
-      live_at_raise := Reg.Set.remove Proc.loc_exn_bucket before_handler;
-      let before_body = live body at_join in
-      live_at_raise := saved_live_at_raise;
-      i.live <- before_body;
-      before_body
+  | Iifthenelse _
+  | Iswitch _ ->
+      i.live <- next;
+      Reg.add_set_array next i.arg
+  | Iend | Icatch _ | Iexit _ | Itrywith _ ->
+      i.live <- next;
+      next
   | Iraise _ ->
-      i.live <- !live_at_raise;
-      Reg.add_set_array !live_at_raise i.arg
+      i.live <- exn;
+      Reg.add_set_array exn i.arg
 
-let reset () =
-  live_at_raise := Reg.Set.empty;
-  live_at_exit := []
+let exnhandler before_handler =
+  Reg.Set.remove Proc.loc_exn_bucket before_handler
 
 let fundecl f =
-  let initially_live = live f.fun_body Reg.Set.empty in
+  let (initially_live, _) =
+    Analyzer.analyze ~exnhandler ~transfer f.fun_body in
   (* Sanity check: only function parameters can be live at entrypoint *)
   let wrong_live = Reg.Set.diff initially_live (Reg.set_of_array f.fun_args) in
   if not (Reg.Set.is_empty wrong_live) then begin

--- a/asmcomp/liveness.mli
+++ b/asmcomp/liveness.mli
@@ -16,5 +16,4 @@
 (* Liveness analysis.
    Annotate mach code with the set of regs live at each point. *)
 
-val reset : unit -> unit
 val fundecl: Mach.fundecl -> unit

--- a/asmcomp/polling.ml
+++ b/asmcomp/polling.ml
@@ -16,182 +16,182 @@ open Mach
 
 module String = Misc.Stdlib.String
 
-(* Check a sequence of instructions from [f] and return whether
-   they poll (via an alloc or raising an exception) *)
-let rec path_polls (f : Mach.instruction) : bool =
-  match f.desc with
-  | Iifthenelse (_, i0, i1) ->
-      ((path_polls i0) && (path_polls i1)) || (path_polls f.next)
-  | Iswitch (_, acts) ->
-      (Array.for_all path_polls acts) && (path_polls f.next)
-  | Icatch (_, handlers, body) ->
-     (path_polls f.next) && (path_polls body)
-     &&
-     (List.for_all path_polls (List.map (fun (_, handler_code) ->
-      handler_code) handlers))
-  | Itrywith (body, handler) ->
-      (path_polls body) && (path_polls handler) && (path_polls f.next)
-  | Ireturn | Iend | Iexit _ -> false
-  | Iop (Ialloc _)
-  | Iop (Ipoll _)
-  | Iraise _ -> true  (* Iraise included here because it contains a poll *)
-  | Iop _ -> path_polls f.next
+(* Detection of recursive handlers that are not guaranteed to poll
+   at every loop iteration. *)
 
- (* Check a sequence of instructions from [f] and return whether the
-    function prologue requires a poll, by virtue of the instructions not
-    causing a poll already. *)
-let requires_prologue_poll ~future_funcnames (f : Mach.instruction) : bool =
-  let rec check_path i =
-  match i.desc with
-  | Iifthenelse (_, i0, i1) ->
-      (check_path i0) || (check_path i1) || (check_path i.next)
-  | Iswitch (_, acts) ->
-      (Array.exists check_path acts) || (check_path i.next)
-  | Icatch (_, handlers, body) ->
-     (check_path body)
-     ||
-      (List.exists check_path (List.map (fun (_, handler_code) ->
-        handler_code) handlers)) || (check_path i.next)
-  | Itrywith (body, handler) ->
-      (check_path body) || (check_path handler) || (check_path i.next)
-  | Iop (Itailcall_ind) -> true
-  | Iop (Itailcall_imm { func; _ }) ->
-    if (String.Set.mem func future_funcnames) then
-      (* this means we have a call to a function that might be a self call
-         or a call to a future function (which won't have a poll) *)
-      true
-    else
-      check_path i.next
-  | Iop (Ialloc _)
-  | Iop (Ipoll _)
-  | Iraise _ -> false  (* Iraise included here because it contains a poll *)
-  | Iend | Ireturn | Iexit _ -> false
-  | Iop _ -> check_path i.next
-  in check_path f
+(* The result of the analysis is a mapping from handlers H
+   (= loop heads) to Booleans b.
 
-(* This determines whether from a given instruction we unconditionally
-   allocate and this is used to avoid adding polls unnecessarily *)
-let polls_unconditionally (i : Mach.instruction) =
-  path_polls i
+   b is true if every path starting from H goes through an Ialloc,
+   Ipoll, Ireturn, Itailcall_ind or Itailcall_imm instruction.
 
-(* returns a list of ids for the handlers of recursive catches from
-   Mach instruction [f]. These are used to later add polls before
-   exits to them. *)
-let rec find_rec_handlers ~future_funcnames (f : Mach.instruction) =
-  match f.desc with
-  | Iifthenelse (_, ifso, ifnot) ->
-      let ifso_rec_handlers = find_rec_handlers ~future_funcnames ifso in
-      let ifnot_rec_handlers = find_rec_handlers ~future_funcnames ifnot in
-      let next_rec_handlers = find_rec_handlers ~future_funcnames f.next in
-      ifso_rec_handlers @ ifnot_rec_handlers @ next_rec_handlers
-  | Iswitch (_, cases) ->
-      let case_rec_handlers =
-        Array.fold_left
-          (fun agg_rec_handlers case ->
-            agg_rec_handlers @ find_rec_handlers ~future_funcnames case)
-          [] cases
-      in
-      case_rec_handlers @ find_rec_handlers ~future_funcnames f.next
-  | Icatch (rec_flag, handlers, body) -> (
-      match rec_flag with
-      | Recursive ->
-          let rec_handlers =
-            List.map
-              (fun (id, handler) ->
-                let inner_rec_handlers = find_rec_handlers ~future_funcnames
-                  handler in
-                let current_rec_handlers =
-                  if not (polls_unconditionally handler) then [ id ] else []
-                in
-                inner_rec_handlers @ current_rec_handlers)
-              handlers
-            |> List.flatten
-          in
-          let body_rec_handlers = find_rec_handlers ~future_funcnames body in
-          body_rec_handlers @ rec_handlers @ find_rec_handlers
-            ~future_funcnames f.next
-      | Nonrecursive ->
-          let non_rec_catch_handlers =
-            List.fold_left
-              (fun tmp_rec_handlers (_, handler) ->
-                tmp_rec_handlers @ find_rec_handlers ~future_funcnames handler)
-              [] handlers
-          in
-          let body_rec_handlers = find_rec_handlers ~future_funcnames body in
-          body_rec_handlers @ non_rec_catch_handlers @ find_rec_handlers
-            ~future_funcnames f.next
-      )
-  | Itrywith (body, handler) ->
-      let handler_rec_handler = find_rec_handlers ~future_funcnames handler in
-      let body_rec_handlers = find_rec_handlers ~future_funcnames body in
-      body_rec_handlers @ handler_rec_handler @ find_rec_handlers
-        ~future_funcnames f.next
-  | Iexit _ | Iend | Ireturn
-  | Iop (Itailcall_ind)
-  | Iop (Itailcall_imm _)
-  | Iraise _ ->
-      []
-  | Iop _ -> find_rec_handlers ~future_funcnames f.next
+   (Iraise is treated like Ireturn if not handled locally, or like
+    a branch to the nearest enclosing exception handler.)
 
-(* given the list of handler ids [rec_handlers] for recursive catches, add polls
-   before backwards edges starting from Mach instruction [i] *)
-let instrument_body_with_polls (rec_handlers : int list) (i : Mach.instruction)
-    =
-  (* the [current_handlers] list allows for an optimisation which avoids
-    putting a poll before the first jump in to a loop *)
-  let rec instrument_body (current_handlers : int list) (f : Mach.instruction) =
-    let instrument_with_handlers i = instrument_body current_handlers i in
-    match f.desc with
-    | Iifthenelse (test, i0, i1) ->
-        {
-          f with
-          desc = Iifthenelse (
-            test, instrument_with_handlers i0, instrument_with_handlers i1
-          );
-          next = instrument_with_handlers f.next;
-        }
-    | Iswitch (index, cases) ->
-        {
-          f with
-          desc = Iswitch (index, Array.map instrument_with_handlers cases);
-          next = instrument_with_handlers f.next;
-        }
-    | Icatch (rec_flag, handlers, body) ->
-        {
-          f with
-          desc =
-            Icatch
-              ( rec_flag,
-                List.map
-                  (fun (idx, instrs) ->
-                    (idx, instrument_body (idx :: current_handlers) instrs))
-                  handlers,
-                instrument_with_handlers body );
-          next = instrument_with_handlers f.next;
-        }
-    | Itrywith (body, handler) ->
-        {
-          f with
-          desc = Itrywith (
-            instrument_with_handlers body, instrument_with_handlers handler
-          );
-          next = instrument_with_handlers f.next;
-        }
-    | Iexit id ->
-        let new_f = { f with next = instrument_with_handlers f.next } in
-        if List.mem id current_handlers && List.mem id rec_handlers then
-          Mach.instr_cons
-            (Iop (Ipoll { return_label = None }))
-            [||] [||] new_f
-        else new_f
-    | Iend | Ireturn | Iop (Itailcall_ind) | Iop (Itailcall_imm _) | Iraise _
-      ->
-        f
-    | Iop _ -> { f with next = instrument_with_handlers f.next }
+   b is false, therefore, if starting from H we can loop infinitely
+   without crossing an Ialloc or Ipoll instruction.
+*)
+
+(* The analysis is a backward dataflow analysis starting from false,
+   using && (Boolean "and") as the join operator,
+   and with the following transfer function:
+
+   TRANSF(Ialloc | Ipoll | Itailcall_ind | Itailcall_imm _ | Ireturn) = true
+   TRANSF(all other operations, x) = x
+*)
+
+let polled_loops_analysis funbody =
+  let handlers : (int, bool) Hashtbl.t = Hashtbl.create 20 in
+  let get_handler n =
+    match Hashtbl.find_opt handlers n with Some b -> b | None -> false in
+  let set_handler n b =
+    Hashtbl.replace handlers n b in
+  let rec before i end_ exn =
+    match i.desc with
+    | Iend -> end_
+    | Iop (Ialloc _ | Ipoll _ | Itailcall_ind | Itailcall_imm _) -> true
+    | Iop (Icall_ind | Icall_imm _) ->  (* TODO: make sure we can ignore exn *)
+        before i.next end_ exn
+    | Iop op ->
+        if operation_can_raise op
+        then exn && before i.next end_ exn
+        else before i.next end_ exn
+    | Ireturn -> true
+    | Iifthenelse(_, ifso, ifnot) ->
+        let join = before i.next end_ exn in
+        before ifso join exn && before ifnot join exn
+    | Iswitch(_, branches) ->
+        let join = before i.next end_ exn in
+        Array.for_all (fun i -> before i join exn) branches
+    | Icatch (Cmm.Nonrecursive, handlers, body) ->
+        List.iter
+          (fun (n, h) -> set_handler n (before h end_ exn))
+          handlers;
+        before body end_ exn
+    | Icatch (Cmm.Recursive, handlers, body) ->
+        let update changed (n, h) =
+          let b0 = get_handler n in
+          let b1 = before h end_ exn in
+          if b1 = b0 then changed else (set_handler n b1; true) in
+        while List.fold_left update false handlers do () done;
+        before body end_ exn
+    | Iexit n ->
+        get_handler n
+    | Itrywith(body, handler) ->
+        before body end_ (before handler end_ exn)
+    | Iraise _ ->
+        exn
   in
-  instrument_body [] i
+    ignore (before funbody true true);
+    get_handler
 
-let instrument_fundecl ~future_funcnames (i : Mach.fundecl) : Mach.fundecl =
-  let f = i.fun_body in
-  let rec_handlers = find_rec_handlers ~future_funcnames f in
-  { i with fun_body = instrument_body_with_polls rec_handlers f }
+(* Detection of functions that can loop via a tail-call without going
+   through a poll point. *)
+
+(* The result of the analysis is a single Boolean b.
+
+   b is true if there exists a path from the function entry to a
+   Potentially Recursive Tail Call (an Itailcall_ind or
+   Itailcall_imm to a forward function) 
+   that does not go through an Ialloc or Ipoll instruction.
+
+   b is false, therefore, if the function always polls (via Ialloc or Ipoll)
+   before doing a PRTC.
+
+   To compute b, we do a backward dataflow analysis starting from
+   false, using || (Boolean "or") as the join operator, and with the
+   following transfer function:
+
+   TRANSF(Ialloc | Ipoll, x) = false
+   TRANSF(Itailcall_ind, x) = true
+   TRANSF(Itailcall_imm f, x) = f is a forward function
+   TRANSF(all other operations, x) = x
+*)
+
+let potentially_recursive_tailcall ~fwd_func funbody =
+  let handlers : (int, bool) Hashtbl.t = Hashtbl.create 20 in
+  let get_handler n =
+    match Hashtbl.find_opt handlers n with Some b -> b | None -> false in
+  let set_handler n b =
+    Hashtbl.replace handlers n b in
+  let rec before i end_ exn =
+    match i.desc with
+    | Iend -> end_
+    | Iop (Ialloc _ | Ipoll _) -> false
+    | Iop (Itailcall_ind) -> true
+    | Iop (Itailcall_imm { func }) -> String.Set.mem func fwd_func
+    | Iop op ->
+        if operation_can_raise op
+        then exn || before i.next end_ exn
+        else before i.next end_ exn
+    | Ireturn -> false
+    | Iifthenelse(_, ifso, ifnot) ->
+        let join = before i.next end_ exn in
+        before ifso join exn || before ifnot join exn
+    | Iswitch(_, branches) ->
+        let join = before i.next end_ exn in
+        Array.exists (fun i -> before i join exn) branches
+    | Icatch (Cmm.Nonrecursive, handlers, body) ->
+        List.iter
+          (fun (n, h) -> set_handler n (before h end_ exn))
+          handlers;
+        before body end_ exn
+    | Icatch (Cmm.Recursive, handlers, body) ->
+        let update changed (n, h) =
+          let b0 = get_handler n in
+          let b1 = before h end_ exn in
+          if b1 = b0 then changed else (set_handler n b1; true) in
+        while List.fold_left update false handlers do () done;
+        before body end_ exn
+    | Iexit n ->
+        get_handler n
+    | Itrywith(body, handler) ->
+        before body end_ (before handler end_ exn)
+    | Iraise _ ->
+        exn
+  in
+    before funbody false false
+
+(* Given the handlers in scope without intervening allocation,
+   add polls before unguarded backwards edges,
+   starting from Mach instruction [i] *)
+let instr_body handler_ok i =
+  let rec instr i =
+  match i.desc with
+  | Iifthenelse (test, i0, i1) ->
+    { i with
+      desc = Iifthenelse (test, instr i0, instr i1);
+      next = instr i.next;
+    }
+  | Iswitch (index, cases) ->
+    { i with
+      desc = Iswitch (index, Array.map instr cases);
+      next = instr i.next;
+    }
+  | Icatch (rc, hdl, body) ->
+    { i with
+      desc = Icatch (rc,
+                     List.map (fun (n, i0) -> (n, instr i0)) hdl,
+                     instr body);
+      next = instr i.next;
+    }
+  | Itrywith (body, hdl) ->
+    { i with
+      desc = Itrywith (instr body, instr hdl);
+      next = instr i.next;
+    }
+  | Iexit n ->
+    if handler_ok n then
+      i
+    else
+      Mach.instr_cons (Iop (Ipoll { return_label = None })) [||] [||] i
+  | Iend | Ireturn | Iraise _ -> i
+  | Iop _ -> { i with next = instr i.next }
+  in
+    instr i
+
+let instrument_fundecl ~future_funcnames:_ (f : Mach.fundecl) : Mach.fundecl =
+  let handlers_ok = polled_loops_analysis f.fun_body in
+  { f with fun_body = instr_body handlers_ok f.fun_body }
+let requires_prologue_poll ~future_funcnames i =
+  potentially_recursive_tailcall ~fwd_func:future_funcnames i

--- a/compilerlibs/Makefile.compilerlibs
+++ b/compilerlibs/Makefile.compilerlibs
@@ -209,6 +209,7 @@ ASMCOMP = \
   asmcomp/polling.cmo \
   asmcomp/selectgen.cmo \
   asmcomp/selection.cmo \
+  asmcomp/dataflow.cmo \
   asmcomp/comballoc.cmo \
   asmcomp/CSEgen.cmo \
   asmcomp/CSE.cmo \

--- a/compilerlibs/Makefile.compilerlibs
+++ b/compilerlibs/Makefile.compilerlibs
@@ -206,10 +206,10 @@ ASMCOMP = \
   asmcomp/cmm_invariants.cmo \
   asmcomp/interval.cmo \
   asmcomp/printmach.cmo \
+  asmcomp/dataflow.cmo \
   asmcomp/polling.cmo \
   asmcomp/selectgen.cmo \
   asmcomp/selection.cmo \
-  asmcomp/dataflow.cmo \
   asmcomp/comballoc.cmo \
   asmcomp/CSEgen.cmo \
   asmcomp/CSE.cmo \


### PR DESCRIPTION
This PR starts with @damiendoligez's https://github.com/sadiqj/ocaml/pull/3, merges it with @sadiqj's recent work, then:
- Reimplements the static analyses using the new generic dataflow engine.  One of the analyses in https://github.com/sadiqj/ocaml/pull/3 is very incomplete (any loop following an allocation is considered as unsafe).  (I'm the one to blame for this mistake.)  The dataflow framework makes it harder to make that kind of mistakes.
- Removes the optimizations for mutually-recursive handlers.  They need more work to fit in the dataflow framework, and OCaml doesn't currently generate mutually-recursive handlers (AFAIK), so optimizing them can wait.
- For poll point insertion in loops, both poll-at-top-of-loop and poll-at-bottom-of-loop are supported (just change the `poll_location` parameter at line 137 in asmcomp/polling.ml). So, we'll be able to benchmark both approaches and take an informed decision (finally!).

