### PR TITLE
Revise branch relaxation for Ipoll instructions

### DIFF
--- a/asmcomp/arm64/emit.mlp
+++ b/asmcomp/arm64/emit.mlp
@@ -584,9 +584,7 @@ let assembly_code_for_allocation env i ~n ~far ~dbginfo =
   end
 
 let assembly_code_for_poll env i ~far ~return_label =
-  let lbl_frame =
-    record_frame_label env i.live (Dbg_alloc [])
-  in
+  let lbl_frame = record_frame_label env i.live (Dbg_alloc []) in
   let lbl_call_gc = new_label() in
   let lbl_after_poll = match return_label with
   | None -> new_label()
@@ -596,19 +594,23 @@ let assembly_code_for_poll env i ~far ~return_label =
     `	cmp	{emit_reg reg_alloc_ptr}, {emit_reg reg_tmp1}\n`;
   if not far then begin
     match return_label with
-    | None -> `	b.ls	{emit_label lbl_call_gc}\n`
+    | None ->
+        `	b.ls	{emit_label lbl_call_gc}\n`;
+        `{emit_label lbl_after_poll}:\n`
     | Some return_label ->
-      begin
-        ` b.hi {emit_label return_label}\n`;
-        ` b    {emit_label lbl_call_gc}\n`;
-      end
+        `	b.hi	{emit_label return_label}\n`;
+        `	b	{emit_label lbl_call_gc}\n`;
   end else begin
-    `	b.hi	{emit_label lbl_after_poll}\n`;
-    ` b     {emit_label lbl_call_gc}\n`
-  end;
-  begin match return_label with
-  | None -> `{emit_label lbl_after_poll}:`
-  | _ -> ()
+    match return_label with
+    | None ->
+        `	b.hi	{emit_label lbl_after_poll}\n`;
+        `	b	{emit_label lbl_call_gc}\n`;
+        `{emit_label lbl_after_poll}:\n`
+    | Some return_label ->
+        let lbl = new_label () in
+        `	b.ls	{emit_label lbl}\n`;
+        `	b	{emit_label return_label}\n`;
+        `{emit_label lbl}:	b	{emit_label lbl_call_gc}\n`
   end;
   env.call_gc_sites <-
     { gc_lbl = lbl_call_gc;

--- a/asmcomp/branch_relaxation.ml
+++ b/asmcomp/branch_relaxation.ml
@@ -51,7 +51,7 @@ module Make (T : Branch_relaxation_intf.S) = struct
       in
       match instr.desc with
       | Lop (Ialloc _)
-      | Lop (Ipoll _)
+      | Lop (Ipoll { return_label = None })
       | Lop (Iintop (Icheckbound))
       | Lop (Iintop_imm (Icheckbound, _))
       | Lop (Ispecific _) ->
@@ -65,6 +65,11 @@ module Make (T : Branch_relaxation_intf.S) = struct
         opt_branch_overflows map pc lbl0 max_branch_offset
           || opt_branch_overflows map pc lbl1 max_branch_offset
           || opt_branch_overflows map pc lbl2 max_branch_offset
+      | Lop (Ipoll { return_label = Some lbl }) ->
+        (* A poll-and-branch instruction can branch to the label lbl,
+           but also to an out-of-line code block. *)
+        code_size + max_out_of_line_code_offset - pc >= max_branch_offset
+        || branch_overflows map pc lbl max_branch_offset
       | _ ->
         Misc.fatal_error "Unsupported instruction for branch relaxation"
 

--- a/asmcomp/power/emit.mlp
+++ b/asmcomp/power/emit.mlp
@@ -555,16 +555,14 @@ let emit_poll env i return_label far =
       end
     end;
   end else begin
-    let lbl = match return_label with
-      | None -> new_label()
-      | Some lbl -> lbl
-    in
+    let lbl = new_label () in
     `	bge	{emit_label lbl}\n`;
     `	bl	{emit_label env.call_gc_label}\n`;
     record_frame env i.live (Dbg_alloc []);
+    ` {emit_label lbl}:	\n`;
     match return_label with
-    | None ->   ` {emit_label lbl}:	\n`;
-    | Some _ -> ` b   {emit_label lbl}\n`;
+    | None ->   ()
+    | Some return_label -> ` b   {emit_label return_label}\n`
   end
 
 (* Output the assembly code for an instruction *)


### PR DESCRIPTION
This PR tries to address the problem identified at https://github.com/ocaml/ocaml/pull/10039#discussion_r651538518

`Ipoll` with a return label can cause a branch overflow in two ways:
- if the return label is too far away, or
- if the GC call point is too far away.

Here, we make sure both cases trigger Ipoll relaxation, and update the emitters for ARM64 and Power to make sure the code emitted for `Ipoll_far` is correct in both cases.